### PR TITLE
Make DOIs secure again

### DIFF
--- a/spec/0.1/data_crate_specification_v0.1.md
+++ b/spec/0.1/data_crate_specification_v0.1.md
@@ -689,7 +689,7 @@ An organization SHOULD be represented by a *DataCrate Microdocument* with two ty
 
 The following is an example of marking-up a publication, using a DataCrate
 Microdocument with type [schema:ScholarlyArticle]. In this example the ID of the
-document is a DOI URL (http://dx.doi.org/10.1109/TCYB.2014.2386282). IDs for
+document is a DOI URL (https://doi.org/10.1109/TCYB.2014.2386282). IDs for
 publications SHOULD be DOI URLs where possible.
 
 This *DataCrate microdocument* about a publication references people, described
@@ -711,13 +711,13 @@ in an example above with the [schema:creator] property.
     <th>TYPE:</th>
 </tr>
 
-<tr resource='http://dx.doi.org/10.1109/TCYB.2014.2386282'
-    id='http://dx.doi.org/10.1109/TCYB.2014.2386282'  
+<tr resource='https://doi.org/10.1109/TCYB.2014.2386282'
+    id='https://doi.org/10.1109/TCYB.2014.2386282'  
     typeof='http://schema.org/CreativeWork http://schema.org/ScholarlyArticle'
     property='schema:hasPart'>    
   <td>
   <div  property='http://schema.org/identifier'>
-   <a href='http://dx.doi.org/10.1109/TCYB.2014.2386282'>http://dx.doi.org/10.1109/TCYB.2014.2386282</a></div>
+   <a href='https://doi.org/10.1109/TCYB.2014.2386282'>https://doi.org/10.1109/TCYB.2014.2386282</a></div>
    </td>
     <td>
        <div  property='http://schema.org/name'>Topic Model for Graph Mining</div>
@@ -759,7 +759,7 @@ in an example above with the [schema:creator] property.
 A reference a *Data Entity* or *Metadata Entity* or  MUST use the property
 [schema:relatedItem], pointing to a *DataCrate Microdocument*. Building on the
 examples of Organizations, People and Publications above, referencing the
-publication http://dx.doi.org/10.1109/TCYB.2014.2386282 could look like:
+publication https://doi.org/10.1109/TCYB.2014.2386282 could look like:
 
 ```
 <div typeof='http://schema.org/Dataset' about='./data'>
@@ -767,9 +767,9 @@ publication http://dx.doi.org/10.1109/TCYB.2014.2386282 could look like:
 <tr>
   <th>Related</th>
   <td>
-    <div resource='http://dx.doi.org/10.1109/TCYB.2014.2386282'
+    <div resource='https://doi.org/10.1109/TCYB.2014.2386282'
          property='http://schema.org/relatedLink'>
-           <a href='#http://dx.doi.org/10.1109/TCYB.2014.2386282'>
+           <a href='#https://doi.org/10.1109/TCYB.2014.2386282'>
               Topic Model for Graph Mining
            </a>
       </div>
@@ -786,7 +786,7 @@ the following *DataCrate-framed JSON-LD*.
     "@type": "Dataset",
     "@id": "./",
     "Related": {
-      "@id": "http://dx.doi.org/10.1109/TCYB.2014.2386282",
+      "@id": "https://doi.org/10.1109/TCYB.2014.2386282",
       "Name": "Topic Model for Graph Mining",
       "@type": [
         "ScholarlyArticle",
@@ -866,7 +866,7 @@ the following *DataCrate-framed JSON-LD*.
           }
         }
       ],
-      "ID": "http://dx.doi.org/10.1109/TCYB.2014.2386282"
+      "ID": "https://doi.org/10.1109/TCYB.2014.2386282"
     }
 ```
 

--- a/spec/0.1/samples/sample/CATALOG.html
+++ b/spec/0.1/samples/sample/CATALOG.html
@@ -48,7 +48,7 @@ div.collection {
 
                         <div class="container">
                          <div class="jumbotron">
-                           <h2>Cite this data:</h2><h3>Peter Sefton (2017) Sample dataset for DataCrate v0.1. University of Technology Sydney. Datacrate. http://dx.doi.org/10.5281/zenodo.1009240</h3>Citation metadata is in <a href='./datacite.xml'>datacite.xml</a>
+                           <h2>Cite this data:</h2><h3>Peter Sefton (2017) Sample dataset for DataCrate v0.1. University of Technology Sydney. Datacrate. https://doi.org/10.5281/zenodo.1009240</h3>Citation metadata is in <a href='./datacite.xml'>datacite.xml</a>
                          </div>
                         <p>This catalog file describes a dataset.
                            It uses the <a href='https://github.com/UTS-eResearch/datacrate/blob/master/spec/0.1/data_crate_specification_v0.1.md'>
@@ -74,7 +74,7 @@ div.collection {
 </tr>
 <tr>
   <th>ID</th>
-  <td><div  property='http://schema.org/identifier'><a href='http://dx.doi.org/10.5281/zenodo.1009240'><span class='break'>http://dx.doi.org/10.5281/zenodo.1009240</span></a></div>
+  <td><div  property='http://schema.org/identifier'><a href='https://doi.org/10.5281/zenodo.1009240'><span class='break'>https://doi.org/10.5281/zenodo.1009240</span></a></div>
 </td>
 </tr>
 <tr>
@@ -104,7 +104,7 @@ div.collection {
 </tr>
 <tr>
   <th>RelatedLink</th>
-  <td><a href='http://dx.doi.org/10.1000/123456'>http://dx.doi.org/10.1000/123456</a></td>
+  <td><a href='https://doi.org/10.1000/123456'>https://doi.org/10.1000/123456</a></td>
 </tr>
 <tr>
   <th>Publisher</th>
@@ -289,7 +289,7 @@ No additional restrictions — You may not apply legal terms or technological me
     <th>TYPE:</th>
 </tr></thead>
 
-<tbody class='table-striped'><tr resource='http://dx.doi.org/10.1000/123456' id='http://dx.doi.org/10.1000/123456'  typeof='CreativeWork' property='http://schema.org/hasPart'>    <td><div  property='http://schema.org/identifier'><a href='http://dx.doi.org/10.1000/123456'><span class='break'>http://dx.doi.org/10.1000/123456</span></a></div>
+<tbody class='table-striped'><tr resource='https://doi.org/10.1000/123456' id='https://doi.org/10.1000/123456'  typeof='CreativeWork' property='http://schema.org/hasPart'>    <td><div  property='http://schema.org/identifier'><a href='https://doi.org/10.1000/123456'><span class='break'>https://doi.org/10.1000/123456</span></a></div>
 </td>
     <td><div  property='http://schema.org/name'>This is an example publication with a dodgy DOI</div>
 </td>

--- a/spec/0.1/samples/sample/CATALOG.json
+++ b/spec/0.1/samples/sample/CATALOG.json
@@ -188,8 +188,8 @@
           "Name": "EPL1 Camera"
         },
         {
-          "@id": "http://dx.doi.org/10.1000/123456",
-          "ID": "http://dx.doi.org/10.1000/123456",
+          "@id": "https://doi.org/10.1000/123456",
+          "ID": "https://doi.org/10.1000/123456",
           "Name": "This is an example publication with a dodgy DOI"
         },
         {
@@ -208,7 +208,7 @@
           "@id": "http://uts.edu.au"
         }
       ],
-      "ID": "http://dx.doi.org/10.5281/zenodo.1009240",
+      "ID": "https://doi.org/10.5281/zenodo.1009240",
       "Name": "Sample dataset for DataCrate v0.1",
       "Publisher": {
         "@id": "http://uts.edu.au",

--- a/spec/0.1/samples/sample/bag-info.txt
+++ b/spec/0.1/samples/sample/bag-info.txt
@@ -6,5 +6,5 @@ Contact-Telephone:
 Contact-email: pt@ptsefton.com
 DataCrate-Specification-Identifier: https://github.com/UTS-eResearch/datacrate/blob/develop/spec/0.1/data_crate_specification_v0.1.md
 External-Description: This is a simple dataset for demonstration purposes it contains just one image and a directory full of useless text files.
-External-Identifier: http://dx.doi.org/10.5281/zenodo.1009240
+External-Identifier: https://doi.org/10.5281/zenodo.1009240
 Payload-Oxum: 163143.204

--- a/spec/0.2/data_crate_specification_v0.2.md
+++ b/spec/0.2/data_crate_specification_v0.2.md
@@ -632,14 +632,14 @@ To associate a publication with a dataset the *DataCreate Flattened JSON-LD* MUS
 
 For example:
 ```
-"related": {"@id": "http://dx.doi.org/10.1109/TCYB.2014.2386282"}
+"related": {"@id": "https://doi.org/10.1109/TCYB.2014.2386282"}
 ```
 
 The publication SHOULD be described in the *DataCrate Flattened JSON-LD*.
 
 ```
 {
-  "@id": "http://dx.doi.org/10.1109/TCYB.2014.2386282",
+  "@id": "https://doi.org/10.1109/TCYB.2014.2386282",
   "@type": "ScholarlyArticle",
   "creator": [
     {
@@ -655,7 +655,7 @@ The publication SHOULD be described in the *DataCrate Flattened JSON-LD*.
       "@id": "https://orcid.org/0000-0002-6953-3986"
     }
   ],
-  "identifier": "http://dx.doi.org/10.1109/TCYB.2014.2386282",
+  "identifier": "https://doi.org/10.1109/TCYB.2014.2386282",
   "issn": "2168-2267",
   "name": "Topic Model for Graph Mining",
   "journal": "IEEE Transactions on Cybernetics",
@@ -670,7 +670,7 @@ should be a an [Organization] though it MAY be a string-literal or a URI.
 
 ```
 {
-  "@id": "http://dx.doi.org/10.5281/zenodo.1009240",
+  "@id": "https://doi.org/10.5281/zenodo.1009240",
   "@type": "Dataset",
    <...>
   "name": "Sample dataset for DataCrate v0.2",
@@ -698,7 +698,7 @@ properties. The [isOutputOf] property MAY also be used to associate a dataset wi
 
 ```
 {
-  "@id": "http://dx.doi.org/10.5281/zenodo.1009240",
+  "@id": "https://doi.org/10.5281/zenodo.1009240",
   "@type": "Dataset",
   "isOutputOf": {
     "@id": "https://github.com/UTS-eResearch/datacrate"
@@ -746,7 +746,7 @@ Use the [datePublished] property with a date in ISO 8601 date format to at least
 
 ```
 {
-  "@id": "http://dx.doi.org/10.5281/zenodo.1009240",
+  "@id": "https://doi.org/10.5281/zenodo.1009240",
   "@type": "Dataset",
   "datePublished": "2017-06-29",
 },
@@ -880,7 +880,7 @@ The place has a [geo] property, referencing a [GeoCoordinates] item:
 And the place is referenced from the [contentLocation] property of the dataset.
 ```
 {
-  "@id": "http://dx.doi.org/10.5281/zenodo.1009240",
+  "@id": "https://doi.org/10.5281/zenodo.1009240",
   "@type": "Dataset",
   "outputOf": "DataCrate",
   "contact": {

--- a/spec/0.2/samples/bags/sample/CATALOG.json
+++ b/spec/0.2/samples/bags/sample/CATALOG.json
@@ -88,17 +88,17 @@
       "name": "Australian National Data Service"
     },
     {
-      "@id": "http://dx.doi.org/10.1000/123456",
+      "@id": "https://doi.org/10.1000/123456",
       "@type": "ScholarlyArticle",
       "creator": {
         "@id": "http://orcid.org/0000-0002-3545-944X"
       },
       "datePublished": "2018",
-      "identifier": "http://dx.doi.org/10.1000/123456",
+      "identifier": "https://doi.org/10.1000/123456",
       "name": "This is an example publication with a dodgy DOI"
     },
     {
-      "@id": "http://dx.doi.org/10.5281/zenodo.1009240",
+      "@id": "https://doi.org/10.5281/zenodo.1009240",
       "@type": "Dataset",
       "outputOf": "DataCrate",
       "contact": {
@@ -121,7 +121,7 @@
           "@id": "pics"
         }
       ],
-      "identifier": "http://dx.doi.org/10.5281/zenodo.1009240",
+      "identifier": "https://doi.org/10.5281/zenodo.1009240",
       "keywords": "Dogs, Fences, The Gully",
       "name": "Sample dataset for DataCrate v0.2",
       "publisher": {

--- a/spec/0.2/samples/bags/sample/index.html
+++ b/spec/0.2/samples/bags/sample/index.html
@@ -38,7 +38,7 @@
 <body>
 <div class="container">
 <div class="jumbotron">
-Cite this work: <h3>Peter Sefton (2017) Sample dataset for DataCrate v0.2. University of Technology Sydney. Datacrate. http://dx.doi.org/10.5281/zenodo.1009240</h3>
+Cite this work: <h3>Peter Sefton (2017) Sample dataset for DataCrate v0.2. University of Technology Sydney. Datacrate. https://doi.org/10.5281/zenodo.1009240</h3>
 </div>
 <p>This catalog file describes a dataset.
 It uses the <a href='https://github.com/UTS-eResearch/datacrate/blob/master/spec/0.2/data_crate_specification_v0.1.md'>
@@ -53,7 +53,7 @@ A machine-readable version of this page is available:
 
 <?xml version="1.0"?>
 <div>
-  <table class="table" id="http://dx.doi.org/10.5281/zenodo.1009240">
+  <table class="table" id="https://doi.org/10.5281/zenodo.1009240">
     <tr>
       <th>OutputOf</th>
       <td>DataCrate</td>
@@ -97,7 +97,7 @@ A machine-readable version of this page is available:
     <tr>
       <th>Name</th>
       <td>
-        <a href="http://dx.doi.org/10.5281/zenodo.1009240">Sample dataset for DataCrate v0.2</a>
+        <a href="https://doi.org/10.5281/zenodo.1009240">Sample dataset for DataCrate v0.2</a>
       </td>
     </tr>
     <tr>
@@ -320,9 +320,9 @@ A machine-readable version of this page is available:
       </tr>
     </thead>
     <tbody class="table-striped"></tbody>
-    <tr id="http://dx.doi.org/10.1000/123456">
+    <tr id="https://doi.org/10.1000/123456">
       <td>
-        <a href="http://dx.doi.org/10.1000/123456">This is an example publication with a dodgy DOI</a>
+        <a href="https://doi.org/10.1000/123456">This is an example publication with a dodgy DOI</a>
       </td>
       <td>2018</td>
       <td>

--- a/spec/0.2/samples/timluckett/CATALOG.html
+++ b/spec/0.2/samples/timluckett/CATALOG.html
@@ -50,7 +50,7 @@ div.collection {
 </tr>
 <tr>
   <th>Funder</th>
-  <td><div href='http://dx.doi.org/10.13039/501100003921' property='http://schema.org/Funder'><a href='#http://dx.doi.org/10.13039/501100003921'>Australian Department of Health</a></div>
+  <td><div href='https://doi.org/10.13039/501100003921' property='http://schema.org/Funder'><a href='#https://doi.org/10.13039/501100003921'>Australian Department of Health</a></div>
 </td>
 </tr>
 <tr>
@@ -481,7 +481,7 @@ Symptoms and care during the last month of life (Table 5)</div>
     <th>TYPE:</th>
 </tr>
 
-<tr href='http://dx.doi.org/10.13039/501100003921' id='http://dx.doi.org/10.13039/501100003921'  typeof='schema:CreativeWork http://schema.org/Organization' property='schema:hasPart'>    <td><div  property='http://schema.org/identifier'><a href='http://dx.doi.org/10.13039/501100003921'>http://dx.doi.org/10.13039/501100003921</a></div>
+<tr href='https://doi.org/10.13039/501100003921' id='https://doi.org/10.13039/501100003921'  typeof='schema:CreativeWork http://schema.org/Organization' property='schema:hasPart'>    <td><div  property='http://schema.org/identifier'><a href='https://doi.org/10.13039/501100003921'>https://doi.org/10.13039/501100003921</a></div>
 </td>
     <td><div  property='http://schema.org/description'>The IDEAL Study was funded by the Australian Department of Health (previously Department of Health and Ageing). The funder played no role in the research</div>
 </td>

--- a/spec/0.2/samples/timluckett/CATALOG.json
+++ b/spec/0.2/samples/timluckett/CATALOG.json
@@ -125,9 +125,9 @@
             "CreativeWork",
             "Organization"
           ],
-          "@id": "http://dx.doi.org/10.13039/501100003921",
+          "@id": "https://doi.org/10.13039/501100003921",
           "Description": "The IDEAL Study was funded by the Australian Department of Health (previously Department of Health and Ageing). The funder played no role in the research",
-          "ID": "http://dx.doi.org/10.13039/501100003921",
+          "ID": "https://doi.org/10.13039/501100003921",
           "Name": "Australian Department of Health"
         },
         {


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Accordingly, this PR updates static DOI links.

I am unsure whether some of them could be test data which need to match to URL strings fetched from an external resource that does not itself deliver the new, recommended resolver URLs. Please feel free to close this PR in such a case.

Cheers!